### PR TITLE
ability to inject default errorHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
     return '?' + arr.join('&')
   }
 
-  function _fetch (method, url, opts, data, queryParams) {
+  function _fetch (method, url, opts, data, queryParams, errorHandler) {
     opts.method = method
     opts.headers = opts.headers || {}
     opts.responseAs = (opts.responseAs && ['json', 'text'].indexOf(opts.responseAs) >= 0) ? opts.responseAs : 'json'
@@ -36,11 +36,16 @@
         }
         var err = new Error(response.statusText)
         err.response = response
+
+        if(errorHandler) {
+          errorHandler(response)
+        }
+
         throw err
       })
   }
 
-  function fetchival (url, opts) {
+  function fetchival (url, opts, errorHandler) {
     opts = opts || {}
 
     var _ = function (u, o) {
@@ -52,23 +57,24 @@
     }
 
     _.get = function (queryParams) {
-      return _fetch('GET', url, opts, null, queryParams)
+      return _fetch('GET', url, opts, null, queryParams, errorHandler)
     }
 
     _.post = function (data) {
-      return _fetch('POST', url, opts, data)
+      return _fetch('POST', url, opts, data, null, errorHandler)
     }
 
     _.put = function (data) {
-      return _fetch('PUT', url, opts, data)
+      console.log('datadatadatadatadata', data);
+      return _fetch('PUT', url, opts, data, null, errorHandler)
     }
 
     _.patch = function (data) {
-      return _fetch('PATCH', url, opts, data)
+      return _fetch('PATCH', url, opts, data, null, errorHandler)
     }
 
     _.delete = function () {
-      return _fetch('DELETE', url, opts)
+      return _fetch('DELETE', url, opts, null, null, errorHandler)
     }
 
     return _


### PR DESCRIPTION
I need a ability to inject a default error handler, like angular's $http can do.
So I modify a bit to let fetchival can accept errorhandler.
My use case is return to /login page whenever status is 401.

```
var errorhandler = function(response) {
	if (response.status === 401) {
		Cookies.expire('user');
		Cookies.expire('access_token');
		window.location = '/';
	};
}

var API = {
	Orders: fetchival('/api/orders', fetchOptions, errorhandler),
	RefNumber: fetchival('/api/ref_numbers', fetchOptions, errorhandler),
	Stores: fetchival( '/stores', fetchOptions, errorhandler),
}
```