### PR TITLE
Added function registries for encoding, responses, and error handling.

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,20 +72,20 @@
       return _fetch('GET', url, opts, null, queryParams)
     }
 
-    _.post = function (data) {
-      return _fetch('POST', url, opts, data)
+    _.post = function (data, queryParams) {
+      return _fetch('POST', url, opts, data, queryParams)
     }
 
-    _.put = function (data) {
-      return _fetch('PUT', url, opts, data)
+    _.put = function (data, queryParams) {
+      return _fetch('PUT', url, opts, data, queryParams)
     }
 
-    _.patch = function (data) {
-      return _fetch('PATCH', url, opts, data)
+    _.patch = function (data, queryParams) {
+      return _fetch('PATCH', url, opts, data, queryParams)
     }
 
-    _.delete = function () {
-      return _fetch('DELETE', url, opts)
+    _.delete = function (queryParams) {
+      return _fetch('DELETE', url, opts, null, queryParams)
     }
 
     return _

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
   function defaults (target, obj) {
     for (var prop in obj) target[prop] = target[prop] || obj[prop]
+    return target
   }
 
   function getQuery (queryParams) {
@@ -17,8 +18,10 @@
     'response': true
   }
   function _fetch (method, url, opts, data, queryParams) {
+    // Use a shallow copy of opts parameter and opts.header subfield
+    opts = defaults({}, opts)
     opts.method = method
-    opts.headers = opts.headers || {}
+    opts.headers = defaults({}, opts.headers || {})
 
     if (opts.responseAs !== true && typeof opts.responseAs !== 'function') {
       opts.responseAs = responseHandlers[opts.responseAs] || responseHandlers.json

--- a/index.js
+++ b/index.js
@@ -62,9 +62,13 @@
             return null;
           return opts.responseAs(response);
         }
-        var err = new Error(response.statusText)
-        err.response = response
-        throw err
+        if(typeof opts.errorAs !== 'function') {
+          var err = new Error(response.statusText)
+          err.response = response
+          throw err
+        } else {
+          throw opts.errorAs(response)
+        }
       })
   }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -17,6 +17,30 @@ var requestText = fetchival('http://jsonplaceholder.typicode.com', {
   responseAs: 'text'
 })
 
+fetchival.responseHandlers['registered-example'] = function(response) {
+  return response.json()
+    .then(function (json) {
+      return {kind: 'registered-example', json: json, response: response}
+    })
+}
+
+var requestRegisteredExample = fetchival('http://jsonplaceholder.typicode.com', {
+  mode: 'cors',
+  headers: { 'X-TEST': 'test' },
+  responseAs: 'registered-example'
+})
+
+var requestCustomExample = fetchival('http://jsonplaceholder.typicode.com', {
+  mode: 'cors',
+  headers: { 'X-TEST': 'test' },
+  responseAs: function(response) {
+    return response.json()
+      .then(function (json) {
+        return {kind: 'custom', json: json, response: response}
+      })
+  }
+})
+
 describe('fetchival', function () {
   this.timeout(5000)
   this.slow(5000)
@@ -135,4 +159,37 @@ describe('fetchival', function () {
         })
     })
   })
+
+  describe('requestCustomExample(posts/1/comments)', function () {
+    var posts = requestCustomExample('posts')
+    var comments = posts(1 + '/comments')
+
+    it('should #get()', function (done) {
+      comments
+        .get()
+        .then(function (extendedReponseObj) {
+          assert.equal('custom', extendedReponseObj.kind)
+          assert(extendedReponseObj.response.ok)
+          assert(extendedReponseObj.json.length)
+          done()
+        })
+    })
+  })
+
+  describe('requestRegisteredExample(posts/1/comments)', function () {
+    var posts = requestRegisteredExample('posts')
+    var comments = posts(1 + '/comments')
+
+    it('should #get()', function (done) {
+      comments
+        .get()
+        .then(function (extendedReponseObj) {
+          assert.equal('registered-example', extendedReponseObj.kind)
+          assert(extendedReponseObj.response.ok)
+          assert(extendedReponseObj.json.length)
+          done()
+        })
+    })
+  })
+
 })


### PR DESCRIPTION
This is a composite set of patches to allow simple adaptation of the fetchival abstraction, allowing for non-json data types like FormData, ArrayBuffer, Blob, etc. I also added an extensibility for response type handling, as well as custom error handlers.

This also includes a bug fix for modifying `opts` parameter and the shared `opts.headers` sub-object. 

This PR encompasses PR https://github.com/typicode/fetchival/pull/8 and PR https://github.com/typicode/fetchival/pull/10, as well as issues https://github.com/typicode/fetchival/issues/9 and https://github.com/typicode/fetchival/issues/18