### PR TITLE
won't set Content-Type header when body is not preset

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,15 @@
     opts.headers = opts.headers || {}
     opts.responseAs = (opts.responseAs && ['json', 'text', 'response'].indexOf(opts.responseAs) >= 0) ? opts.responseAs : 'json'
 
-    defaults(opts.headers, {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    })
+    var defaultHeaders = {
+      'Accept': 'application/json'
+    };
+
+    if (!!data) {
+      defaultHeaders['Content-Type'] = 'application/json'
+    }
+
+    defaults(opts.headers, defaultHeaders)
 
     if (queryParams) {
       url += getQuery(queryParams)


### PR DESCRIPTION
- setting Content-Type:'application/json' is confusing when there is no body in the request

According to W3:

> The purpose of the Content-Type field is to describe the data contained in the body fully enough that the receiving user agent can pick an appropriate agent or mechanism to present the data to the user, or otherwise deal with the data in an appropriate manner.

